### PR TITLE
Allow to select a SketchRNN model

### DIFF
--- a/sketch-rnn/http-server.js
+++ b/sketch-rnn/http-server.js
@@ -95,6 +95,14 @@ app.post('/simple_predict_absolute', function(req, res) {
 
     // Get strokes from the POST request's parameters
     var strokes = req.body.strokes;
+    var model = req.body.model;
+    if (model) {
+        console.log("Requesting model " + model);
+        simple_predict.load_model(model);
+    } 
+    else {
+        console.log("No model requested");
+    }
 
     // If strokes are provided on the request,
     // set them as input strokes for simple_predict

--- a/sketch-rnn/lib/simple_predict.js
+++ b/sketch-rnn/lib/simple_predict.js
@@ -49,8 +49,9 @@ module.exports.load_sketch_rnn = function() {
 }
 
 module.exports.load_model = function(model_name) {
+    console.log("Loading " + model_name);
     let model = require('./models/' + model_name + '.gen.js');
-    model_raw_data = JSON.stringify(bird_model);
+    model_raw_data = JSON.stringify(model);
 }
 
 module.exports.output_strokes = function() {


### PR DESCRIPTION
This pull request allows to select a SketchRNN model by including the `model` parameter with the name of the SketchRNN model (say, `bicycle` or `bird` or `crab`).

Thanks @garciadelcastillo =)